### PR TITLE
Provide new functionality to ensure that internal operations don't disguise imprecision

### DIFF
--- a/src/exceptions/OverflowException.php
+++ b/src/exceptions/OverflowException.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Money
+ *
+ * Copyright (c) 2012-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    Money
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2012-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.github.com/sebastianbergmann/money
+ */
+namespace SebastianBergmann\Money;
+
+/**
+ * Exception that is throw when when an amount overflows valid integers
+ *
+ * @package    Money
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2012-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.github.com/sebastianbergmann/money
+ */
+class OverflowException extends \OverflowException implements Exception
+{
+}


### PR DESCRIPTION
In certain cases it is possible for the Money object to deal in numbers
which overflow the integer limit of PHP this introduces errors that a
users of the package will not be aware of. This commit causes
failure by throwing an exception when a to-be-cast number is out of integer
bounds.

An example:

On a 64-bit system with a PHP_INT_MAX of 9223372036854775807 the following
code can run without error, and without the user realising an error state
has been produced (the error state is that ->amount will be -9223372036854775808):

```
$m = new Money(4611686018427387904, new Currency('USD'));
$newM = $m->multiply(2);
```

Internally, the following analogous operation is occurring:

```
intval(4611686018427387904 * 2)
```

Which produces the result "-9223372036854775808", a clear error state.
