### PR TITLE
Throw more informative exceptions when addition and subtract cause overflow

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -119,12 +119,17 @@ class Money
      * @param  \SebastianBergmann\Money\Money $other
      * @return \SebastianBergmann\Money\Money
      * @throws \SebastianBergmann\Money\CurrencyMismatchException
+     * @throws \SebastianBergmann\Money\OverflowException
      */
     public function add(Money $other)
     {
         $this->assertSameCurrency($this, $other);
 
-        return $this->newMoney($this->amount + $other->getAmount());
+        $value = $this->amount + $other->getAmount();
+
+        $this->assertIntegerOperationDidntOverflow($value);
+
+        return $this->newMoney($value);
     }
 
     /**
@@ -134,12 +139,17 @@ class Money
      * @param  \SebastianBergmann\Money\Money $other
      * @return \SebastianBergmann\Money\Money
      * @throws \SebastianBergmann\Money\CurrencyMismatchException
+     * @throws \SebastianBergmann\Money\OverflowException
      */
     public function subtract(Money $other)
     {
         $this->assertSameCurrency($this, $other);
 
-        return $this->newMoney($this->amount - $other->getAmount());
+        $value = $this->amount - $other->getAmount();
+
+        $this->assertIntegerOperationDidntOverflow($value);
+
+        return $this->newMoney($value);
     }
 
     /**
@@ -341,6 +351,21 @@ class Money
     private function assertNoOverflow($amount)
     {
         if (abs($amount) > PHP_INT_MAX) {
+            throw new OverflowException;
+        }
+    }
+
+    /**
+     * Throws an exception if what is meant to be an integer is not
+     * 
+     * This is an indication of overflow when you are operating on integers
+     * 
+     * @param number $value
+     * @throws \SebastianBergmann\Money\OverflowException
+     */
+    private function assertIntegerOperationDidntOverflow($value)
+    {
+        if (!is_int($value)) {
             throw new OverflowException;
         }
     }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -107,6 +107,23 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            \SebastianBergmann\Money\Money::add
+     * @covers            \SebastianBergmann\Money\Money::newMoney
+     * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
+     * @uses              \SebastianBergmann\Money\Money::__construct
+     * @uses              \SebastianBergmann\Money\Money::getAmount
+     * @uses              \SebastianBergmann\Money\Money::getCurrency
+     * @uses              \SebastianBergmann\Money\Currency
+     * @expectedException \SebastianBergmann\Money\OverflowException
+     */
+    public function testExceptionIsThrownForOverflowingAddition()
+    {
+        $a = new Money(PHP_INT_MAX, new Currency('EUR'));
+        $b = new Money(2, new Currency('EUR'));
+        $a->add($b);
+    }
+
+    /**
      * @covers            \SebastianBergmann\Money\Money::assertNoOverflow
      * @uses              \SebastianBergmann\Money\Money::__construct
      * @uses              \SebastianBergmann\Money\Money::multiply
@@ -155,6 +172,23 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $a->getAmount());
         $this->assertEquals(2, $b->getAmount());
         $this->assertEquals(1, $c->getAmount());
+    }
+
+    /**
+     * @covers            \SebastianBergmann\Money\Money::subtract
+     * @covers            \SebastianBergmann\Money\Money::newMoney
+     * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
+     * @uses              \SebastianBergmann\Money\Money::__construct
+     * @uses              \SebastianBergmann\Money\Money::getAmount
+     * @uses              \SebastianBergmann\Money\Money::getCurrency
+     * @uses              \SebastianBergmann\Money\Currency
+     * @expectedException \SebastianBergmann\Money\OverflowException
+     */
+    public function testExceptionIsThrownForOverflowingSubtraction()
+    {
+        $a = new Money(-PHP_INT_MAX, new Currency('EUR'));
+        $b = new Money(2, new Currency('EUR'));
+        $a->subtract($b);
     }
 
     /**


### PR DESCRIPTION
Currently an InvalidArgumentException is thrown during overflow causing
addition and subtract.

This exception type is not very informative, and because it is an
internal operation that is causing it, a more informative exception
should be thrown.

With this change, where it is expected that an operation should produce
an integer, when it doesn't the Money object now throws an OverflowException
