### PR TITLE
Added RoundingMode for extractPercentage method

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -296,13 +296,16 @@ class Money
      * represented by a Money object) instead.
      *
      * @param  float $percentage
+     * @param  integer $roundingMode
      * @return \SebastianBergmann\Money\Money[]
      * @see    https://github.com/sebastianbergmann/money/issues/27
      */
-    public function extractPercentage($percentage)
+    public function extractPercentage($percentage, $roundingMode = PHP_ROUND_HALF_UP)
     {
         $percentage = $this->newMoney(
-            intval($this->amount / (100 + $percentage) * $percentage)
+            $this->castToInt(
+                round($this->amount / (100 + $percentage) * $percentage, 0, $roundingMode)
+            )
         );
 
         return array(

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -379,8 +379,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $original = new Money(10000, new Currency('EUR'));
         $extract  = $original->extractPercentage(21);
 
-        $this->assertEquals(new Money(8265, new Currency('EUR')), $extract['subtotal']);
-        $this->assertEquals(new Money(1735, new Currency('EUR')), $extract['percentage']);
+        $this->assertEquals(new Money(8264, new Currency('EUR')), $extract['subtotal']);
+        $this->assertEquals(new Money(1736, new Currency('EUR')), $extract['percentage']);
     }
 
     /**


### PR DESCRIPTION
The `extractPercentage` method was not using any rounding resulting in wrong amounts.

See rules for rounding VAT of Dutch VAT Agency:
http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/facturen_maken/btw-bedrag_afronden

Translation:

```
You use for the completion of the amount of VAT the arithmetic method. If the amount of VAT due on the invoice consists of more than two decimal places, it rounds to the 3rd decimal place off to whole cents. This is done as follows:

Is the 3rd decimal place is less than 5, you round off the amount downwards.
Is the 3rd decimal place 5 or higher, then you complete the amount upwards.
This means for example that you finalize € 20.124 to € 20.125 and € 20.12 to € 20.13.

Upon completion, you can choose from two methods:

You rounds off a well supplied or rendered performance.
You complete the total off.
You may not use both methods together. And you have to follow a fixed line in your choice to use a method.

The return of VAT to complete the VAT amounts to whole dollars. You may do your advantage.
```
