### PR TITLE
Add Currency::getCurrencies() to access registered currencies

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -1165,6 +1165,14 @@ class Currency
     }
 
     /**
+     * @return array the list of configured currencies
+     */
+    public static function getCurrencies()
+    {
+        return self::$currencies;
+    }
+
+    /**
      * Returns the ISO 4217 currency code of this currency.
      *
      * @return string

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -65,6 +65,23 @@ class CurrencyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \SebastianBergmann\Money\Currency::getCurrencies
+     */
+    public function testRegisterdCurrenciesCanBeAccessed()
+    {
+        $currencies = Currency::getCurrencies();
+
+        $this->assertTrue(is_array($currencies), 'Registered currencies should be an array');
+        $this->assertArrayHasKey('EUR', $currencies);
+        $this->assertTrue(is_array($currencies['EUR']), 'Registered currencies should be an array');
+        $this->assertArrayHasKey('display_name', $currencies['EUR']);
+        $this->assertArrayHasKey('numeric_code', $currencies['EUR']);
+        $this->assertArrayHasKey('default_fraction_digits', $currencies['EUR']);
+        $this->assertArrayHasKey('sub_unit', $currencies['EUR']);
+
+    }
+
+    /**
      * @covers  \SebastianBergmann\Money\Currency::__toString
      * @depends testCanBeConstructedFromUppercaseString
      */


### PR DESCRIPTION
This could be useful if you want to list supported currencies.

I think it would be better than doing this:
https://github.com/sebastianbergmann/money/blob/b1f97e9f7da4a625027798cb8cb9c856a2fcde07/build/generate-child-classes.php#L15-L17