### PR TITLE
update `getAmount` to return either base units or subunits

### DIFF
--- a/src/IntlFormatter.php
+++ b/src/IntlFormatter.php
@@ -48,7 +48,7 @@ class IntlFormatter implements Formatter
     public function format(Money $money)
     {
         return $this->numberFormatter->formatCurrency(
-            $money->getAmount() / $money->getCurrency()->getSubUnit(),
+            $money->getAmount(true),
             $money->getCurrency()->getCurrencyCode()
         );
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -116,10 +116,15 @@ class Money implements \JsonSerializable
     /**
      * Returns the monetary value represented by this object.
      *
-     * @return integer
+     * @param bool $convert
+     * @return integer|float
      */
-    public function getAmount()
+    public function getAmount($convert = false)
     {
+        if ($convert) {
+            return round($this->amount / $this->currency->getSubUnit(), $this->currency->getDefaultFractionDigits());
+        }
+        
         return $this->amount;
     }
 


### PR DESCRIPTION
sometimes it is beneficial to return the base unit value of a currency rather than the subunit value. this commit allows us to do that by passing a boolean to the `getAmount` method. this implementation will not break BC, and users can continue to use the `getAmount` method as before.

in fact, the PHP number formatter doesn't do any of this math for you, which is why you needed to include it in your `IntlFormatter`. This commit allows us to move that responsibility from the formatter to the `Money` class.

if the mixed return types bothers you, I could also extract this out into a separate method, something like `getConvertedAmount()`