### PR TITLE
add vendor dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/pdepend
 build/phpdox
 cache.properties
 .idea
+vendor


### PR DESCRIPTION
the composer generated `vendor` directory should not be included in
commits