### PR TITLE
create method to retrieve amount converted to base units

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ $m = new Money(100, new Currency('EUR'));
 
 // Access the Money object's monetary value
 print $m->getAmount();
+
+// Access the Money object's monetary value converted to its base units
+print $m->getConvertedAmount();
 ```
 
 The code above produces the output shown below:
 
     100
+    
+    1.00
 
 #### Creating a Money object from a string value
 

--- a/src/IntlFormatter.php
+++ b/src/IntlFormatter.php
@@ -48,7 +48,7 @@ class IntlFormatter implements Formatter
     public function format(Money $money)
     {
         return $this->numberFormatter->formatCurrency(
-            $money->getAmount() / $money->getCurrency()->getSubUnit(),
+            $money->getConvertedAmount(),
             $money->getCurrency()->getCurrencyCode()
         );
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -124,6 +124,16 @@ class Money implements \JsonSerializable
     }
 
     /**
+     * return the monetary value represented by this object converted to its base units
+     *
+     * @return float
+     */
+    public function getConvertedAmount()
+    {
+        return round($this->amount / $this->currency->getSubUnit(), $this->currency->getDefaultFractionDigits());
+    }
+
+    /**
      * Returns the currency of the monetary value represented by this
      * object.
      *

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -109,6 +109,15 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \SebastianBergmann\Money\Money::getConvertedAmount
+     */
+    public function testConvertedAmountCanBeRetrieved()
+    {
+        $m = new Money(1234, 'EUR');
+        $this->assertSame(12.34, $m->getConvertedAmount());
+    }
+
+    /**
      * @covers  \SebastianBergmann\Money\Money::getCurrency
      * @uses    \SebastianBergmann\Money\Currency
      * @depends testObjectCanBeConstructedForValidConstructorArguments


### PR DESCRIPTION
`getConvertedAmount` converts the `Money`s value into its base units
(dollars, euros, etc) and rounds to the appropriate digits.

update the `IntlFormatter` to use this new method.

add test for method.

update readme to explain how to use method