### PR TITLE
fix link

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 All notable changes to `sebastianbergmann/money` will be documented in this file. Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## [2.0.0] (not yet released)
+## [2.0.0] - not yet released
 
 ### Removed
 * Dropped support for PHP < 5.4.0


### PR DESCRIPTION
it was treating `not yet released` as the link url, rather than referencing the link at the bottom. reformatting so it works correctly.

my bad