### PR TITLE
accept different amount types, and either base units or subunits

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,9 +8,14 @@ All notable changes to `sebastianbergmann/money` will be documented in this file
 * Added the `Money::getConvertedAmount()` method for converting a `Money` object's amount into its base units
 * Added the `Currency::getCurrencies()` method for retrieving the registered currencies
 * Added the `IntlFormatter::fromLocale()` named constructor to create `IntlFormatter` objects for a specified locale
+* Added the ability to pass in multiple types of values to the `Money` constructor, not just integers. It will now take integers, floats, strings integers (`[0-9]+`), and string floats (`[0-9]+(\.[0-9]+)?`), and convert them appropriately for internal storage as integers.
+* Added a 3rd parameter to the `Money` constructor which allows the user to pass in a value in either the currency's subunits (ex. cents) or base units (ex. dollar). Parameters defaults to `false` and the value is interpreted as subunits, but if `true` is passed `Money` class will treat the value as base units, and convert them for internal storage appropriately.
 
 ### Changed
 * The constructor of the `IntlFormatter` class now expects a `NumberFormatter` object
+
+## Deprecated
+* `Money::fromString()` method which allowed to create a money object from a string. A string value can now be passed to the constructor, and `Money` will interpret it appropriately
 
 ### Removed
 * Removed support for PHP < 5.5.0

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -14,6 +14,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @covers            \SebastianBergmann\Money\Money::__construct
+     * @covers            \SebastianBergmann\Money\Money::setCurrency
+     * @covers            \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Currency
      * @expectedException \SebastianBergmann\Money\InvalidArgumentException
      */
@@ -24,7 +26,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers            \SebastianBergmann\Money\Money::__construct
-     * @covers            \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @covers            \SebastianBergmann\Money\Money::setCurrency
+     * @covers            \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Currency
      * @expectedException \SebastianBergmann\Money\InvalidArgumentException
      */
@@ -44,8 +47,21 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            \SebastianBergmann\Money\Money::__construct
+     * @covers            \SebastianBergmann\Money\Money::setCurrency
+     * @covers            \SebastianBergmann\Money\Money::setAmount
+     * @uses              \SebastianBergmann\Money\Currency
+     * @expectedException \SebastianBergmann\Money\InvalidArgumentException
+     */
+    public function testExceptionIsRaisedForInvalidConstructorArguments4()
+    {
+        new Money('nonnumericstring', new Currency('EUR'));
+    }
+
+    /**
      * @covers \SebastianBergmann\Money\Money::__construct
-     * @covers \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @covers \SebastianBergmann\Money\Money::setCurrency
+     * @covers \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
     public function testObjectCanBeConstructedForValidConstructorArguments()
@@ -59,7 +75,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \SebastianBergmann\Money\Money::__construct
-     * @covers \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @covers \SebastianBergmann\Money\Money::setCurrency
+     * @covers \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
     public function testObjectCanBeConstructedForValidConstructorArguments2()
@@ -73,6 +90,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \SebastianBergmann\Money\Money::fromString
+     * @covers \SebastianBergmann\Money\Money::setCurrency
+     * @covers \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::__construct
      * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
      * @uses   \SebastianBergmann\Money\Currency
@@ -87,6 +106,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \SebastianBergmann\Money\Money::fromString
+     * @covers \SebastianBergmann\Money\Money::setCurrency
+     * @covers \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::__construct
      * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
      * @uses   \SebastianBergmann\Money\Currency
@@ -97,6 +118,110 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
             new Money(1234, new Currency('EUR')),
             Money::fromString('12.34', 'EUR')
         );
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedFromInteger()
+    {
+        $m = new Money(1234, 'EUR');
+        $this->assertEquals(1234, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedAndConvertedFromInteger()
+    {
+        $m = new Money(1234, 'EUR', true);
+        $this->assertEquals(123400, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedFromFloat()
+    {
+        $m = new Money(1234.56, 'EUR');
+        $this->assertEquals(1235, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedAndConvertedFromFloat()
+    {
+        $m = new Money(1234.56, 'EUR', true);
+        $this->assertEquals(123456, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedFromIntegerString()
+    {
+        $m = new Money('1234', 'EUR');
+        $this->assertEquals(1234, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedAndConvertedFromIntegerString()
+    {
+        $m = new Money('1234', 'EUR', true);
+        $this->assertEquals(123400, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedFromFloatString()
+    {
+        $m = new Money('1234.56', 'EUR');
+        $this->assertEquals(1235, $m->getAmount());
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::setAmount
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testObjectCanBeConstructedAndConvertedFromFloatString()
+    {
+        $m = new Money('1234.56', 'EUR', true);
+        $this->assertEquals(123456, $m->getAmount());
     }
 
     /**
@@ -112,7 +237,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers \SebastianBergmann\Money\Money::getConvertedAmount
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
     public function testConvertedAmountCanBeRetrieved()
@@ -137,7 +263,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @covers \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Money::getCurrency
      * @uses   \SebastianBergmann\Money\Money::assertIsInteger
@@ -160,7 +287,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
      * @covers            \SebastianBergmann\Money\Money::assertIsInteger
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::getAmount
      * @uses              \SebastianBergmann\Money\Money::getCurrency
      * @uses              \SebastianBergmann\Money\Currency
@@ -176,7 +304,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers            \SebastianBergmann\Money\Money::assertInsideIntegerBounds
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::multiply
      * @uses              \SebastianBergmann\Money\Money::castToInt
      * @uses              \SebastianBergmann\Money\Currency
@@ -192,7 +321,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers            \SebastianBergmann\Money\Money::add
      * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::getAmount
      * @uses              \SebastianBergmann\Money\Money::getCurrency
      * @uses              \SebastianBergmann\Money\Currency
@@ -211,7 +341,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @covers \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Money::getCurrency
      * @uses   \SebastianBergmann\Money\Money::assertIsInteger
@@ -234,7 +365,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
      * @covers            \SebastianBergmann\Money\Money::assertIsInteger
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::getAmount
      * @uses              \SebastianBergmann\Money\Money::getCurrency
      * @uses              \SebastianBergmann\Money\Currency
@@ -251,7 +383,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers            \SebastianBergmann\Money\Money::subtract
      * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::getAmount
      * @uses              \SebastianBergmann\Money\Money::getCurrency
      * @uses              \SebastianBergmann\Money\Currency
@@ -269,7 +402,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::negate
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
@@ -287,7 +421,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @covers \SebastianBergmann\Money\Money::castToInt
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Money::assertInsideIntegerBounds
      * @uses   \SebastianBergmann\Money\Currency
@@ -304,7 +439,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers            \SebastianBergmann\Money\Money::multiply
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Currency
      * @expectedException \SebastianBergmann\Money\InvalidArgumentException
      */
@@ -318,7 +454,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::allocateToTargets
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
@@ -355,7 +492,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @uses   \SebastianBergmann\Money\Money::assertInsideIntegerBounds
      * @uses   \SebastianBergmann\Money\Money::castToInt
      * @uses   \SebastianBergmann\Money\Money::newMoney
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Currency
      */
     public function testPercentageCanBeExtracted()
@@ -370,7 +508,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers            \SebastianBergmann\Money\Money::allocateToTargets
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Currency
      * @expectedException \SebastianBergmann\Money\InvalidArgumentException
      */
@@ -385,7 +524,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::newMoney
      * @covers \SebastianBergmann\Money\Money::castToInt
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Money::assertInsideIntegerBounds
      * @uses   \SebastianBergmann\Money\Currency
@@ -408,7 +548,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::compareTo
      * @covers \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses   \SebastianBergmann\Money\Money::__construct
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      * @uses   \SebastianBergmann\Money\Money::getAmount
      * @uses   \SebastianBergmann\Money\Money::getCurrency
      * @uses   \SebastianBergmann\Money\Currency
@@ -427,7 +568,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers  \SebastianBergmann\Money\Money::greaterThan
      * @covers  \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses    \SebastianBergmann\Money\Money::__construct
-     * @uses    \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses    \SebastianBergmann\Money\Money::setCurrency
+     * @uses    \SebastianBergmann\Money\Money::setAmount
      * @uses    \SebastianBergmann\Money\Money::compareTo
      * @uses    \SebastianBergmann\Money\Money::getAmount
      * @uses    \SebastianBergmann\Money\Money::getCurrency
@@ -447,7 +589,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers  \SebastianBergmann\Money\Money::lessThan
      * @covers  \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses    \SebastianBergmann\Money\Money::__construct
-     * @uses    \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses    \SebastianBergmann\Money\Money::setCurrency
+     * @uses    \SebastianBergmann\Money\Money::setAmount
      * @uses    \SebastianBergmann\Money\Money::compareTo
      * @uses    \SebastianBergmann\Money\Money::getAmount
      * @uses    \SebastianBergmann\Money\Money::getCurrency
@@ -467,7 +610,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers  \SebastianBergmann\Money\Money::equals
      * @covers  \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses    \SebastianBergmann\Money\Money::__construct
-     * @uses    \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses    \SebastianBergmann\Money\Money::setCurrency
+     * @uses    \SebastianBergmann\Money\Money::setAmount
      * @uses    \SebastianBergmann\Money\Money::compareTo
      * @uses    \SebastianBergmann\Money\Money::getAmount
      * @uses    \SebastianBergmann\Money\Money::getCurrency
@@ -489,7 +633,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers  \SebastianBergmann\Money\Money::greaterThanOrEqual
      * @covers  \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses    \SebastianBergmann\Money\Money::__construct
-     * @uses    \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses    \SebastianBergmann\Money\Money::setCurrency
+     * @uses    \SebastianBergmann\Money\Money::setAmount
      * @uses    \SebastianBergmann\Money\Money::greaterThan
      * @uses    \SebastianBergmann\Money\Money::equals
      * @uses    \SebastianBergmann\Money\Money::compareTo
@@ -514,7 +659,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers  \SebastianBergmann\Money\Money::lessThanOrEqual
      * @covers  \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses    \SebastianBergmann\Money\Money::__construct
-     * @uses    \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses    \SebastianBergmann\Money\Money::setCurrency
+     * @uses    \SebastianBergmann\Money\Money::setAmount
      * @uses    \SebastianBergmann\Money\Money::lessThan
      * @uses    \SebastianBergmann\Money\Money::equals
      * @uses    \SebastianBergmann\Money\Money::compareTo
@@ -539,7 +685,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers            \SebastianBergmann\Money\Money::compareTo
      * @covers            \SebastianBergmann\Money\Money::assertSameCurrency
      * @uses              \SebastianBergmann\Money\Money::__construct
-     * @uses              \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses              \SebastianBergmann\Money\Money::setCurrency
+     * @uses              \SebastianBergmann\Money\Money::setAmount
      * @uses              \SebastianBergmann\Money\Money::getCurrency
      * @uses              \SebastianBergmann\Money\Currency
      * @expectedException \SebastianBergmann\Money\CurrencyMismatchException
@@ -556,7 +703,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @covers \SebastianBergmann\Money\Money::jsonSerialize
      * @uses   \SebastianBergmann\Money\Money::__construct
      * @uses   \SebastianBergmann\Money\Currency
-     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::setCurrency
+     * @uses   \SebastianBergmann\Money\Money::setAmount
      */
     public function testCanBeSerializedToJson()
     {
@@ -565,4 +713,5 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
             json_encode(new EUR(1))
         );
     }
+
 }


### PR DESCRIPTION
sorry for the size of this PR, but it was difficult to break it down into smaller parts, as they were all very intertwined.

This PR attempts to address 3 issues:

1. consolidate creation of a `Money` object.
2. allow user to pass any type of numeric variable to create a `Money` object.
3. be explicit whether amount passed is in the currencies base units (i.e dollars) or subunits (cents)

---

1 - currently users can create a `Money` object 1 of 2 ways:

+ through the constructor
+ through the `::fromString()` static method

Ideally the user would create all `Money` objects through the constructor. this enforces one point of entry, and can help prevent inconsistencies in the way the object is created. i realize the `fromString` method was put in place to address a specific problem, but that is addressed in number 2 below

2 - currently the user can create a `Money` object by passing an integer to the constructor, or passing a string to the static `::fromString()` method. this means the `Money` object cannot be created from a float. All three of these variable types are legitimate userland occurrences, and `Money` should be capable of handling all of them.  this puts the responsibility on `Money` and takes it off the user, and allows for more consistency and fewer errors. the new `setAmount` method is capable of handling all of these types, but will also throw an exception (as it did before) if it is passed something it does not know how to handle (for example, a non-numeric string).  Internally the value will still be stored as an integer, but this method is `Money`s way of converting the input to that integer.

Why do we need this? While it would be great if we'd only get integers, no one is ever that lucky in the real world. we have input coming in from many sources (client, database, 3rd party API). this takes the burden off the users to convert their variables to an appropriate type, and places the burden appropriately on the `Money` object.

3 - currently there is some inconsistency between the value set when using the constructor and when using the `::fromString()` method. for example

````php
$usingConstructor = new Money(1234, 'usd');
$usingMethod = Money::fromString('1234', 'usd');

echo $usingConstructor->getAmount();     // 1234
echo $usingMethod->getAmount();           // 123400
````

this is because the `::fromString()` method multiplies the input by the currencies `getSubunit()` value, which in the case of the USD is 100. this implicit behavior is not immediately apparent to the user, and is liable to cause confusion.  a more consistent implementation would be to allow the user to explicitly declare if they would like the input value treated as if it were the currencies base units. this is made possible by the 3rd constructor parameter called `convert`.  it is a boolean value, and has a default value of `false`. this means by default the value is treated as the currencies subunits, but can be overridden.

Why do we need this? Obviously ideally we would handle everything in subunits, but there are many cases, like when dealing with 3rd party APIs, that we are given a value in base units rather than subunits. One specific example is the Easypost Shipping API, which returns a float value in dollars (i.e. 1.23). while we could leave this up to the user, again we can provide consistency by internalizing this responsibility to the Money value object.

### how does this affect the public API?

+ `fromString()` method will be deprecated, in favor of constructor instantiation
+ 3rd optional parameter on the constructor

again, sorry for the length. thanks for checking this out, and let me know if you have any questions or comments.