### PR TITLE
IntlFormatter is optional, suggest ext-intl instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.5"
+    },
+    "require-dev": {
         "ext-intl": "*"
+    },
+    "suggest": {
+        "ext-intl": "Allow international formatting of currencies."
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Allows users that don't have/want ext-intl to use 99% of the features of
this library.