### PR TITLE
Allocate negative amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,33 @@ The code above produces the output shown below:
     10
     9
 
+Works for negative amounts, too.
+
+```php
+use SebastianBergmann\Money\Currency;
+use SebastianBergmann\Money\Money;
+
+// Create a Money object that represents -0,99 EUR
+$a = new Money(-99, new Currency('EUR'));
+
+foreach ($a->allocateToTargets(10) as $t) {
+    print $t->getAmount() . "\n";
+}
+```
+
+The code above produces the output shown below:
+
+    -10
+    -10
+    -10
+    -10
+    -10
+    -10
+    -10
+    -10
+    -10
+    -9
+
 #### Allocate the monetary value represented by a Money object using a list of ratios
 
 ```php
@@ -222,6 +249,25 @@ The code above produces the output shown below:
 
     2
     3
+
+Works for negative amounts, too.
+
+```php
+use SebastianBergmann\Money\Currency;
+use SebastianBergmann\Money\Money;
+
+// Create a Money object that represents -0,05 EUR
+$a = new Money(-5, new Currency('EUR'));
+
+foreach ($a->allocateByRatios(array(3, 7)) as $t) {
+    print $t->getAmount() . "\n";
+}
+```
+
+The code above produces the output shown below:
+
+    -2
+    -3
 
 #### Extract a percentage (and a subtotal) from the monetary value represented by a Money object
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -233,17 +233,19 @@ class Money implements \JsonSerializable
             throw new InvalidArgumentException('$n must be an integer');
         }
 
-        $low       = $this->newMoney(intval($this->amount / $n));
-        $high      = $this->newMoney($low->getAmount() + 1);
-        $remainder = $this->amount % $n;
-        $result    = [];
+        $sign       = ($this->amount < 0) ? -1 : 1;
+        $amount     = abs($this->amount);
+        $low        = $this->newMoney(intval($amount / $n));
+        $high       = $this->newMoney($low->getAmount() + 1);
+        $remainder  = $amount % $n;
+        $result     = [];
 
         for ($i = 0; $i < $remainder; $i++) {
-            $result[] = $high;
+            $result[] = $high->multiply($sign);
         }
 
         for ($i = $remainder; $i < $n; $i++) {
-            $result[] = $low;
+            $result[] = $low->multiply($sign);
         }
 
         return $result;
@@ -261,16 +263,18 @@ class Money implements \JsonSerializable
         /** @var \SebastianBergmann\Money\Money[] $result */
         $result    = [];
         $total     = array_sum($ratios);
-        $remainder = $this->amount;
+        $sign      = ($this->amount < 0) ? -1 : 1;
+        $absAmount = abs($this->amount);
+        $remainder = $absAmount;
 
         for ($i = 0; $i < count($ratios); $i++) {
-            $amount     = $this->castToInt($this->amount * $ratios[$i] / $total);
-            $result[]   = $this->newMoney($amount);
+            $amount     = $this->castToInt($absAmount * $ratios[$i] / $total);
+            $result[]   = $this->newMoney($amount)->multiply($sign);
             $remainder -= $amount;
         }
 
         for ($i = 0; $i < $remainder; $i++) {
-            $result[$i] = $this->newMoney($result[$i]->getAmount() + 1);
+            $result[$i] = $this->newMoney($result[$i]->getAmount() + $sign);
         }
 
         return $result;

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -345,6 +345,36 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \SebastianBergmann\Money\Money::allocateToTargets
+     * @covers \SebastianBergmann\Money\Money::newMoney
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testNegativeAmountCanBeAllocatedToNumberOfTargets()
+    {
+        $a = new Money(-99, new Currency('EUR'));
+        $r = $a->allocateToTargets(10);
+
+        $this->assertEquals(
+            [
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-10, new Currency('EUR')),
+                new Money(-9, new Currency('EUR'))
+            ],
+            $r
+        );
+    }
+
+    /**
      * @covers \SebastianBergmann\Money\Money::extractPercentage
      * @uses   \SebastianBergmann\Money\Money::__construct
      * @uses   \SebastianBergmann\Money\Money::getAmount
@@ -399,6 +429,30 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
             [
                 new Money(2, new Currency('EUR')),
                 new Money(3, new Currency('EUR'))
+            ],
+            $r
+        );
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::allocateByRatios
+     * @covers \SebastianBergmann\Money\Money::newMoney
+     * @covers \SebastianBergmann\Money\Money::castToInt
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Money::getAmount
+     * @uses   \SebastianBergmann\Money\Money::assertInsideIntegerBounds
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testNegativeAmountCanBeAllocatedByRatios()
+    {
+        $a = new Money(-5, new Currency('EUR'));
+        $r = $a->allocateByRatios([3, 7]);
+
+        $this->assertEquals(
+            [
+                new Money(-2, new Currency('EUR')),
+                new Money(-3, new Currency('EUR'))
             ],
             $r
         );


### PR DESCRIPTION
Applies to #65 

* Fixed allocateToTargets for negative amounts
* Fixed allocateByRatios for negative amounts
* Added test for allocateToTargets with negative amount
* Added test for allocateByRatios with negative amount
* Extended the method behaviour documentation for negative amounts in README.md