### PR TITLE
Add __toString method

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -476,4 +476,12 @@ class Money implements \JsonSerializable
 
         return $currency;
     }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->currency->getCurrencyCode() . ' ' . (string)$this->getConvertedAmount();
+    }
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -627,4 +627,16 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
             json_encode(new EUR(1))
         );
     }
+
+    /**
+     * @covers \SebastianBergmann\Money\Money::__toString
+     * @uses   \SebastianBergmann\Money\Money::__construct
+     * @uses   \SebastianBergmann\Money\Money::getConvertedAmount
+     * @uses   \SebastianBergmann\Money\Money::handleCurrencyArgument
+     * @uses   \SebastianBergmann\Money\Currency
+     */
+    public function testCanBeCastToString()
+    {
+        $this->assertEquals('EUR 12.34',(string)(new EUR(1234)));
+    }
 }


### PR DESCRIPTION
Had some trouble with debugging when my application was attempting to cast the Money object to a string (for example in error messages), as it has no `__toString` method implemented.

I followed the general consensus for English of placing the 3 letter ISO currency code before the converted value for the representation.