### PR TITLE
Update Currency.php

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -173,6 +173,12 @@ class Currency
         'default_fraction_digits' => 2,
         'sub_unit' => 100,
       ],
+      'BYN' => [
+        'display_name' => 'Belarussian Ruble',
+        'numeric_code' => 933,
+        'default_fraction_digits' => 0,
+        'sub_unit' => 100,
+      ],
       'BYR' => [
         'display_name' => 'Belarussian Ruble',
         'numeric_code' => 974,


### PR DESCRIPTION
see https://de.wikipedia.org/wiki/ISO_4217#Alphabetische_Codes
new currency valid for Belarus since July 2016